### PR TITLE
Update docker-compose hotfix

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,6 +51,8 @@ SMTP_FROM_NAME=CrowdQR
 REGISTRY=ghcr.io
 REPOSITORY=grayplex/crowdqr
 CROWDQR_VERSION=latest
+CLOUDFLARE_DNS_API_TOKEN=your_cloudflare_dns_api_token_here_change_this
+CLOUDFLARE_EMAIL=youremail@domain.com
 
 # Application URLs (Production)
 # -----------------------------

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -159,6 +159,7 @@ services:
 
 networks:
   crowdqr-network:
+    name: crowdqr-network
     driver: bridge
 
 volumes:


### PR DESCRIPTION
This pull request introduces two key updates to the project configuration files: the addition of Cloudflare-related environment variables and the explicit naming of the network in the Docker Compose setup.

Configuration updates:

* [`.env.example`](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cR54-R55): Added `CLOUDFLARE_DNS_API_TOKEN` and `CLOUDFLARE_EMAIL` environment variables to support Cloudflare DNS integration.

Docker Compose updates:

* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R162): Explicitly set the name of the `crowdqr-network` to ensure consistent network naming across environments.