### PR TITLE
Potential fix for code scanning alert no. 18: Log entries created from user input

### DIFF
--- a/src/CrowdQR.Api/Services/AuthService.cs
+++ b/src/CrowdQR.Api/Services/AuthService.cs
@@ -302,8 +302,8 @@ public class AuthService(
         }
         catch (Exception ex)
         {
-            var sanitizedEmail = email.Replace("\n", "").Replace("\r", "");
-            _logger.LogError(ex, "Error resending verification email to {Email}", sanitizedEmail);
+            var hashedEmail = Convert.ToBase64String(Encoding.UTF8.GetBytes(email));
+            _logger.LogError(ex, "Error resending verification email to a user with hashed email: {HashedEmail}", hashedEmail);
             return false;
         }
     }

--- a/src/CrowdQR.Api/Services/AuthService.cs
+++ b/src/CrowdQR.Api/Services/AuthService.cs
@@ -302,7 +302,8 @@ public class AuthService(
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error resending verification email to {Email}", email);
+            var sanitizedEmail = email.Replace("\n", "").Replace("\r", "");
+            _logger.LogError(ex, "Error resending verification email to {Email}", sanitizedEmail);
             return false;
         }
     }


### PR DESCRIPTION
Potential fix for [https://github.com/grayplex/CrowdQR/security/code-scanning/18](https://github.com/grayplex/CrowdQR/security/code-scanning/18)

To fix the issue, the `email` parameter should be sanitized before being logged. Since the log entries are plain text, we can remove newline characters and other potentially harmful characters from the `email` string. This can be achieved using `String.Replace` or a similar method to ensure that the log output cannot be manipulated by malicious input.

The fix involves:
1. Sanitizing the `email` parameter in the `ResendVerificationEmail` method before logging it.
2. Replacing newline characters (`\n` and `\r`) with an empty string to prevent log forging.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
