### PR TITLE
Potential fix for code scanning alert no. 17: Log entries created from user input

### DIFF
--- a/src/CrowdQR.Api/Services/AuthService.cs
+++ b/src/CrowdQR.Api/Services/AuthService.cs
@@ -267,7 +267,8 @@ public class AuthService(
         catch (Exception ex)
         {
             var sanitizedEmail = verifyEmailDto.Email.Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", "");
-            _logger.LogError(ex, "Error verifying email {Email}", sanitizedEmail);
+            var hashedEmail = Convert.ToBase64String(System.Security.Cryptography.SHA256.HashData(Encoding.UTF8.GetBytes(sanitizedEmail)));
+            _logger.LogError(ex, "Error verifying email for hashed email {HashedEmail}", hashedEmail);
             return false;
         }
     }

--- a/src/CrowdQR.Api/Services/AuthService.cs
+++ b/src/CrowdQR.Api/Services/AuthService.cs
@@ -266,9 +266,7 @@ public class AuthService(
         }
         catch (Exception ex)
         {
-            var sanitizedEmail = verifyEmailDto.Email.Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", "");
-            var hashedEmail = Convert.ToBase64String(System.Security.Cryptography.SHA256.HashData(Encoding.UTF8.GetBytes(sanitizedEmail)));
-            _logger.LogError(ex, "Error verifying email for hashed email {HashedEmail}", hashedEmail);
+            _logger.LogError(ex, "Error verifying email during the verification process.");
             return false;
         }
     }

--- a/src/CrowdQR.Api/Services/AuthService.cs
+++ b/src/CrowdQR.Api/Services/AuthService.cs
@@ -266,7 +266,8 @@ public class AuthService(
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error verifying email {Email}", verifyEmailDto.Email);
+            var sanitizedEmail = verifyEmailDto.Email.Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", "");
+            _logger.LogError(ex, "Error verifying email {Email}", sanitizedEmail);
             return false;
         }
     }


### PR DESCRIPTION
Potential fix for [https://github.com/grayplex/CrowdQR/security/code-scanning/17](https://github.com/grayplex/CrowdQR/security/code-scanning/17)

To fix the issue, the user-provided `verifyEmailDto.Email` value should be sanitized before being logged. Specifically:
1. Remove newline characters from the email string using `String.Replace` to prevent log forging in plain text logs.
2. Optionally, HTML-encode the email string using `System.Net.WebUtility.HtmlEncode` if the logs are displayed in an HTML format.

The fix involves modifying the `_logger.LogError` call on line 269 in `AuthService.cs` to sanitize the `verifyEmailDto.Email` value before logging it.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
