### PR TITLE
Potential fix for code scanning alert no. 16: Log entries created from user input

### DIFF
--- a/src/CrowdQR.Api/Services/AuthService.cs
+++ b/src/CrowdQR.Api/Services/AuthService.cs
@@ -223,7 +223,8 @@ public class AuthService(
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error registering DJ user {Username}", registerDto.Username);
+            var sanitizedUsername = registerDto.Username.Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", "");
+            _logger.LogError(ex, "Error registering DJ user {Username}", sanitizedUsername);
             return new AuthResultDto
             {
                 Success = false,


### PR DESCRIPTION
Potential fix for [https://github.com/grayplex/CrowdQR/security/code-scanning/16](https://github.com/grayplex/CrowdQR/security/code-scanning/16)

To fix the issue, sanitize the `registerDto.Username` before logging it. Since the log entries are plain text, remove any newline characters from the username using `String.Replace`. This ensures that malicious users cannot inject newlines or other special characters into the logs.

The fix involves modifying the `_logger.LogError` call in the `RegisterDj` method of `AuthService` to sanitize `registerDto.Username`. Specifically:
1. Replace newline characters (`Environment.NewLine`) in `registerDto.Username` with an empty string.
2. Ensure the sanitized username is used in the log message.

No additional dependencies are required for this fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
