### PR TITLE
Potential fix for code scanning alert no. 15: Log entries created from user input

### DIFF
--- a/src/CrowdQR.Api/Services/AuthService.cs
+++ b/src/CrowdQR.Api/Services/AuthService.cs
@@ -74,7 +74,8 @@ public class AuthService(
                 _context.Users.Add(user);
                 await _context.SaveChangesAsync();
 
-                _logger.LogInformation("Created new user {Username} with Audience role", usernameOrEmail);
+                var sanitizedUsernameOrEmail = usernameOrEmail.Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", "");
+                _logger.LogInformation("Created new user {Username} with Audience role", sanitizedUsernameOrEmail);
             }
             else
             {


### PR DESCRIPTION
Potential fix for [https://github.com/grayplex/CrowdQR/security/code-scanning/15](https://github.com/grayplex/CrowdQR/security/code-scanning/15)

To fix the issue, sanitize the `usernameOrEmail` parameter before logging it. Since the logs are likely plain text, remove newline characters and other potentially problematic characters from the user input. This can be achieved using `String.Replace` or similar methods. Additionally, ensure that the sanitized input is clearly marked in the log entry to avoid confusion.

The best approach is to replace the direct use of `usernameOrEmail` in the log statement with a sanitized version. This involves creating a helper method or inline sanitization to remove newline characters and other problematic characters.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
