### PR TITLE
Potential fix for code scanning alert no. 14: Log entries created from user input

### DIFF
--- a/src/CrowdQR.Api/Services/AuthService.cs
+++ b/src/CrowdQR.Api/Services/AuthService.cs
@@ -1,6 +1,7 @@
 ﻿using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Text;
+using System.Security.Cryptography;
 using CrowdQR.Api.Data;
 using CrowdQR.Api.Models;
 using CrowdQR.Shared.Models.DTOs;
@@ -139,7 +140,8 @@ public class AuthService(
         catch (Exception ex)
         {
             var sanitizedUsernameOrEmail = usernameOrEmail.Replace("\n", "").Replace("\r", "");
-            _logger.LogError(ex, "Error authenticating user {UsernameOrEmail}", sanitizedUsernameOrEmail);
+            var hashedUsernameOrEmail = Convert.ToBase64String(SHA256.HashData(Encoding.UTF8.GetBytes(sanitizedUsernameOrEmail)));
+            _logger.LogError(ex, "Error authenticating user {HashedUsernameOrEmail}", hashedUsernameOrEmail);
             return new AuthResultDto
             {
                 Success = false,

--- a/src/CrowdQR.Api/Services/AuthService.cs
+++ b/src/CrowdQR.Api/Services/AuthService.cs
@@ -138,7 +138,8 @@ public class AuthService(
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error authenticating user {UsernameOrEmail}", usernameOrEmail);
+            var sanitizedUsernameOrEmail = usernameOrEmail.Replace("\n", "").Replace("\r", "");
+            _logger.LogError(ex, "Error authenticating user {UsernameOrEmail}", sanitizedUsernameOrEmail);
             return new AuthResultDto
             {
                 Success = false,


### PR DESCRIPTION
Potential fix for [https://github.com/grayplex/CrowdQR/security/code-scanning/14](https://github.com/grayplex/CrowdQR/security/code-scanning/14)

To fix the issue, sanitize the `usernameOrEmail` parameter before logging it. Specifically:
1. Remove newline characters (`\n`, `\r`) from the input using `String.Replace`.
2. Optionally, encode the input if logs are displayed in HTML format (e.g., using `System.Net.WebUtility.HtmlEncode`).

The fix will be applied in the `AuthService.AuthenticateUser` method, where the `usernameOrEmail` parameter is logged. This ensures that any user-provided input is sanitized before being written to the logs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
