### PR TITLE
Potential fix for code scanning alert no. 13: Log entries created from user input

### DIFF
--- a/src/CrowdQR.Api/Services/EmailService.cs
+++ b/src/CrowdQR.Api/Services/EmailService.cs
@@ -28,7 +28,8 @@ public class EmailService(ILogger<EmailService> logger, IConfiguration configura
         var sanitizedVerificationUrl = verificationUrl.Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", "");
 
         _logger.LogInformation("----- VERIFICATION EMAIL -----");
-        _logger.LogInformation("To: {Email}", sanitizedEmail);
+        var maskedEmail = sanitizedEmail.Substring(0, Math.Min(3, sanitizedEmail.Length)) + "***";
+        _logger.LogInformation("To: {Email}", maskedEmail);
         _logger.LogInformation("Subject: Verify your CrowdQR DJ account");
         _logger.LogInformation("Body:");
         _logger.LogInformation("Hello {Username},", sanitizedUsername);

--- a/src/CrowdQR.Api/Services/EmailService.cs
+++ b/src/CrowdQR.Api/Services/EmailService.cs
@@ -21,15 +21,21 @@ public class EmailService(ILogger<EmailService> logger, IConfiguration configura
         var baseUrl = _configuration["AppSettings:BaseUrl"] ?? "https://localhost:5000";
         var verificationUrl = $"{baseUrl}/verify-email?email={Uri.EscapeDataString(email)}&token={Uri.EscapeDataString(token)}";
 
+        // Sanitize user input to prevent log forging
+        var sanitizedEmail = email.Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", "");
+        var sanitizedUsername = username.Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", "");
+        var sanitizedToken = token.Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", "");
+        var sanitizedVerificationUrl = verificationUrl.Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", "");
+
         _logger.LogInformation("----- VERIFICATION EMAIL -----");
-        _logger.LogInformation("To: {Email}", email);
+        _logger.LogInformation("To: {Email}", sanitizedEmail);
         _logger.LogInformation("Subject: Verify your CrowdQR DJ account");
         _logger.LogInformation("Body:");
-        _logger.LogInformation("Hello {Username},", username);
+        _logger.LogInformation("Hello {Username},", sanitizedUsername);
         _logger.LogInformation("Thank you for registering as a DJ on CrowdQR.");
         _logger.LogInformation("Please verify your email by clicking the link below:");
-        _logger.LogInformation("{Url}", verificationUrl);
-        _logger.LogInformation("Or use the following verification code: {Token}", token);
+        _logger.LogInformation("{Url}", sanitizedVerificationUrl);
+        _logger.LogInformation("Or use the following verification code: {Token}", sanitizedToken);
         _logger.LogInformation("This link will expire in 24 hours.");
         _logger.LogInformation("If you did not create this account, please ignore this email.");
         _logger.LogInformation("Thanks,");


### PR DESCRIPTION
Potential fix for [https://github.com/grayplex/CrowdQR/security/code-scanning/13](https://github.com/grayplex/CrowdQR/security/code-scanning/13)

To fix the issue, user input should be sanitized before being logged. Specifically:
1. Remove newline characters from user input using `String.Replace` or similar methods to prevent log forging in plain text logs.
2. Ensure that user input is clearly marked in log entries to avoid confusion.
3. For HTML-based logs (if applicable), encode user input using `HttpUtility.HtmlEncode` or similar methods to prevent HTML injection.

In this case, the `email`, `username`, and `token` values should be sanitized before being passed to `_logger.LogInformation`. This can be achieved by replacing newline characters with an empty string.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
