### PR TITLE
Potential fix for code scanning alert no. 12: Log entries created from user input

### DIFF
--- a/src/CrowdQR.Api/Services/EmailService.cs
+++ b/src/CrowdQR.Api/Services/EmailService.cs
@@ -25,7 +25,8 @@ public class EmailService(ILogger<EmailService> logger, IConfiguration configura
         _logger.LogInformation("To: {Email}", email);
         _logger.LogInformation("Subject: Verify your CrowdQR DJ account");
         _logger.LogInformation("Body:");
-        _logger.LogInformation("Hello {Username},", username);
+        var sanitizedUsername = username.Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", "");
+        _logger.LogInformation("Hello {Username},", sanitizedUsername);
         _logger.LogInformation("Thank you for registering as a DJ on CrowdQR.");
         _logger.LogInformation("Please verify your email by clicking the link below:");
         _logger.LogInformation("{Url}", verificationUrl);


### PR DESCRIPTION
Potential fix for [https://github.com/grayplex/CrowdQR/security/code-scanning/12](https://github.com/grayplex/CrowdQR/security/code-scanning/12)

To fix the issue, sanitize the `username` parameter before logging it. Specifically, remove newline characters and other potentially harmful characters from the input. This can be achieved using `String.Replace` or similar methods. The sanitized value should then be used in the log entry.

Changes will be made to the `SendVerificationEmailAsync` method in `src/CrowdQR.Api/Services/EmailService.cs`. The sanitization logic will ensure that the `username` parameter is safe for logging.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
