### PR TITLE
Potential fix for code scanning alert no. 10: Log entries created from user input

### DIFF
--- a/src/CrowdQR.Api/Middleware/AuthorizationLoggingMiddleware.cs
+++ b/src/CrowdQR.Api/Middleware/AuthorizationLoggingMiddleware.cs
@@ -34,7 +34,7 @@ public class AuthorizationLoggingMiddleware(RequestDelegate next, ILogger<Author
         {
             var user = context.User?.Identity?.Name ?? "Anonymous";
             var userId = context.User?.FindFirstValue(ClaimTypes.NameIdentifier) ?? "Unknown";
-            var path = context.Request.Path;
+            var path = context.Request.Path.ToString().Replace("\n", "").Replace("\r", "");
             var method = context.Request.Method;
             var clientIp = context.Connection.RemoteIpAddress?.ToString() ?? "Unknown";
 


### PR DESCRIPTION
Potential fix for [https://github.com/grayplex/CrowdQR/security/code-scanning/10](https://github.com/grayplex/CrowdQR/security/code-scanning/10)

To fix the issue, sanitize the user-provided input (`context.Request.Path`) before including it in the log message. Since the log entries are plain text, remove any newline characters or other potentially problematic characters from the input. This can be achieved using `String.Replace` or similar methods.

The fix involves:
1. Sanitizing `context.Request.Path` by replacing newline characters (`\n` and `\r`) with an empty string.
2. Updating the construction of the `message` variable to use the sanitized value.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
