### PR TITLE
Potential fix for code scanning alert no. 9: Log entries created from user input

### DIFF
--- a/src/CrowdQR.Api/Middleware/DjRoleValidationMiddleware.cs
+++ b/src/CrowdQR.Api/Middleware/DjRoleValidationMiddleware.cs
@@ -47,8 +47,9 @@ public class DjRoleValidationMiddleware(RequestDelegate next, ILogger<DjRoleVali
         var roleClaim = context.User.FindFirst(ClaimTypes.Role);
         if (roleClaim == null || roleClaim.Value != UserRole.DJ.ToString())
         {
+            var sanitizedPath = context.Request.Path.Value?.Replace("\n", "").Replace("\r", "");
             _logger.LogWarning("User {UserId} attempted to access DJ-only endpoint {Path} without DJ role",
-                context.User.FindFirst(ClaimTypes.NameIdentifier)?.Value, context.Request.Path);
+                context.User.FindFirst(ClaimTypes.NameIdentifier)?.Value, sanitizedPath);
 
             context.Response.StatusCode = StatusCodes.Status403Forbidden;
             context.Response.ContentType = "application/json";


### PR DESCRIPTION
Potential fix for [https://github.com/grayplex/CrowdQR/security/code-scanning/9](https://github.com/grayplex/CrowdQR/security/code-scanning/9)

To fix the issue, we need to sanitize the `context.Request.Path` value before logging it. Since the log entries are plain text, we should remove any newline characters or other potentially harmful characters from the user input. This can be achieved using the `Replace` method to replace newline characters (`\n` and `\r`) with an empty string. 

The fix will involve modifying the logging statement on line 51 to sanitize `context.Request.Path` before it is logged.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
