### PR TITLE
Potential fix for code scanning alert no. 8: Log entries created from user input

### DIFF
--- a/src/CrowdQR.Api/Controllers/EventController.cs
+++ b/src/CrowdQR.Api/Controllers/EventController.cs
@@ -241,7 +241,7 @@ public class EventController(CrowdQRContext context, ILogger<EventController> lo
         var @event = new Event
         {
             DjUserId = eventDto.DjUserId,
-            Name = eventDto.Name,
+            Name = eventDto.Name?.Replace("\r", "").Replace("\n", ""),
             Slug = eventDto.Slug,
             IsActive = eventDto.IsActive ?? true
         };
@@ -250,7 +250,7 @@ public class EventController(CrowdQRContext context, ILogger<EventController> lo
         await _context.SaveChangesAsync();
         
         _logger.LogInformation("Event created successfully: {EventId}, {EventName}, by DJ {DjUserId}", 
-            @event.EventId, @event.Name, @event.DjUserId);
+            @event.EventId, @event.Name?.Replace("\r", "").Replace("\n", ""), @event.DjUserId);
 
         return CreatedAtAction(nameof(GetEvent), new { id = @event.EventId }, @event);
     }


### PR DESCRIPTION
Potential fix for [https://github.com/grayplex/CrowdQR/security/code-scanning/8](https://github.com/grayplex/CrowdQR/security/code-scanning/8)

To fix the issue, we need to sanitize the `eventDto.Name` field before logging it. Since the log entries are plain text, we should remove newline characters and other potentially problematic characters from the `Name` field. This can be achieved using the `String.Replace` method or similar.

The fix involves:
1. Sanitizing the `eventDto.Name` field before assigning it to `@event.Name`.
2. Ensuring that the sanitized value is used in the log message on line 253.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
